### PR TITLE
missing 'md-input-has-value' if model exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gulp": "^3.9.0",
     "gulp-angular-templatecache": "^1.6.0",
     "gulp-concat": "^2.5.2",
+    "gulp-jscs": "^3.0.2",
     "gulp-minify-html": "^1.0.2",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.2.0",

--- a/src/default.html
+++ b/src/default.html
@@ -1,4 +1,4 @@
-<md-input-container class="schema-form-{{form.type}} {{form.htmlClass}}" sf-messages>
+<md-input-container class="schema-form-{{form.type}} {{form.htmlClass}}" ng-class="{'md-input-has-value':model['{{form.key.slice(-1)[0]}}']}" sf-messages>
   <label  ng-show="showTitle()" for="{{form.key.slice(-1)[0]}}">{{form.title}}</label>
 <!--
   <input ng-if="!form.fieldAddonLeft && !form.fieldAddonRight"


### PR DESCRIPTION
In Angular Materials 1.0.0-rc2, there is an md-input-has-value class that gets added to <md-input-container/> that changes the style of the input field. 

Without it, visibly it looks like the input field has no value until the user clicks on the field.

I have also added the missing gulp-jscs required to run "gulp build".
