### PR TITLE
fix bower main filename

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "Marcel Bennett <iamanthropic@gmail.com>"
   ],
   "description": "Angular Material decorator for Angular Schema Form",
-  "main": "dist/material-decorator.js",
+  "main": "dist/angular-schema-form-material.js",
   "keywords": [
     "angular-schema-form-decorator",
     "angular material",


### PR DESCRIPTION
This pull request fixes the bower main filename since it has been renamed from material-decorator.js to angular-schema-material-decorator.js